### PR TITLE
Uses UICollectionView instead of UIScrollView

### DIFF
--- a/Sources/DIDatepicker.h
+++ b/Sources/DIDatepicker.h
@@ -6,11 +6,9 @@
 #import <UIKit/UIKit.h>
 
 
-extern const NSTimeInterval kSecondsInDay;
-extern const CGFloat kDIDetepickerHeight;
+extern const CGFloat kDIDatepickerHeight;
 
-
-@interface DIDatepicker : UIControl
+@interface DIDatepicker : UIControl <UICollectionViewDataSource, UICollectionViewDelegate>
 
 // data
 @property (strong, nonatomic) NSArray *dates;
@@ -21,7 +19,6 @@ extern const CGFloat kDIDetepickerHeight;
 @property (strong, nonatomic) UIColor *selectedDateBottomLineColor;
 
 // methods
-- (void)fillDatesFromCurrentDate:(NSInteger)nextDatesCount;
 - (void)fillDatesFromDate:(NSDate *)fromDate numberOfDays:(NSInteger)nextDatesCount;
 - (void)fillCurrentWeek;
 - (void)fillCurrentMonth;

--- a/Sources/DIDatepickerDateView.h
+++ b/Sources/DIDatepickerDateView.h
@@ -10,13 +10,10 @@ extern const CGFloat kDIDatepickerItemWidth;
 extern const CGFloat kDIDatepickerSelectionLineWidth;
 
 
-@interface DIDatepickerDateView : UIControl
+@interface DIDatepickerCell : UICollectionViewCell
 
 // data
 @property (strong, nonatomic) NSDate *date;
-@property (assign, nonatomic) BOOL isSelected;
-
-// methods
-- (void)setItemSelectionColor:(UIColor *)itemSelectionColor;
+@property (strong, nonatomic) UIColor *itemSelectionColor;
 
 @end

--- a/Sources/DIDatepickerDateView.m
+++ b/Sources/DIDatepickerDateView.m
@@ -10,104 +10,71 @@ const CGFloat kDIDatepickerItemWidth = 46.;
 const CGFloat kDIDatepickerSelectionLineWidth = 51.;
 
 
-@interface DIDatepickerDateView ()
+@interface DIDatepickerCell ()
 
 @property (strong, nonatomic) UILabel *dateLabel;
 @property (nonatomic, strong) UIView *selectionView;
+@property (nonatomic, strong) NSDateFormatter *dateFormatter;
 
 @end
 
 
-@implementation DIDatepickerDateView
+@implementation DIDatepickerCell
 
 - (id)initWithFrame:(CGRect)frame
 {
-    self = [super initWithFrame:frame];
-    if (!self) return nil;
-
-    [self setupViews];
-
+    if(self = [super initWithFrame:frame]){
+        [self setBackgroundColor:[UIColor clearColor]];
+    }
+    
     return self;
 }
 
-- (void)setupViews
+- (void)prepareForReuse
 {
-    [self addTarget:self action:@selector(dateWasSelected) forControlEvents:UIControlEventTouchUpInside];
+    [self setSelected:NO];
+    self.selectionView.alpha = 0.0f;
 }
+
+#pragma mark - Setters
 
 - (void)setDate:(NSDate *)date
 {
     _date = date;
-
-    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-
-    [dateFormatter setDateFormat:@"dd"];
-    NSString *dayFormattedString = [dateFormatter stringFromDate:date];
-
-    [dateFormatter setDateFormat:@"EEE"];
-    NSString *dayInWeekFormattedString = [dateFormatter stringFromDate:date];
-
-    [dateFormatter setDateFormat:@"MMMM"];
-    NSString *monthFormattedString = [[dateFormatter stringFromDate:date] uppercaseString];
-
+    
+    [self.dateFormatter setDateFormat:@"dd"];
+    NSString *dayFormattedString = [self.dateFormatter stringFromDate:date];
+    
+    [self.dateFormatter setDateFormat:@"EEE"];
+    NSString *dayInWeekFormattedString = [self.dateFormatter stringFromDate:date];
+    
+    [self.dateFormatter setDateFormat:@"MMMM"];
+    NSString *monthFormattedString = [[self.dateFormatter stringFromDate:date] uppercaseString];
+    
     NSMutableAttributedString *dateString = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"%@ %@\n%@", dayFormattedString, [dayInWeekFormattedString uppercaseString], monthFormattedString]];
-
+    
     [dateString addAttributes:@{
                                 NSFontAttributeName: [UIFont fontWithName:@"HelveticaNeue-Thin" size:20],
                                 NSForegroundColorAttributeName: [UIColor blackColor]
-                                }
-                        range:NSMakeRange(0, dayFormattedString.length)];
-
+                                } range:NSMakeRange(0, dayFormattedString.length)];
+    
     [dateString addAttributes:@{
                                 NSFontAttributeName: [UIFont fontWithName:@"HelveticaNeue-Thin" size:8],
                                 NSForegroundColorAttributeName: [UIColor blackColor]
-                                }
-                        range:NSMakeRange(dayFormattedString.length + 1, dayInWeekFormattedString.length)];
-
+                                } range:NSMakeRange(dayFormattedString.length + 1, dayInWeekFormattedString.length)];
+    
     [dateString addAttributes:@{
                                 NSFontAttributeName: [UIFont fontWithName:@"HelveticaNeue-Light" size:8],
                                 NSForegroundColorAttributeName: [UIColor colorWithRed:153./255. green:153./255. blue:153./255. alpha:1.]
-                                }
-                        range:NSMakeRange(dateString.string.length - monthFormattedString.length, monthFormattedString.length)];
-
+                                } range:NSMakeRange(dateString.string.length - monthFormattedString.length, monthFormattedString.length)];
+    
     if ([self isWeekday:date]) {
         [dateString addAttribute:NSFontAttributeName
                            value:[UIFont fontWithName:@"HelveticaNeue-Medium" size:8]
                            range:NSMakeRange(dayFormattedString.length + 1, dayInWeekFormattedString.length)];
     }
-
+    
     self.dateLabel.attributedText = dateString;
-}
-
-- (void)setIsSelected:(BOOL)isSelected
-{
-    _isSelected = isSelected;
-
-    self.selectionView.alpha = (int)_isSelected;
-}
-
-- (UILabel *)dateLabel
-{
-    if (!_dateLabel) {
-        _dateLabel = [[UILabel alloc] initWithFrame:self.bounds];
-        _dateLabel.numberOfLines = 2;
-        _dateLabel.textAlignment = NSTextAlignmentCenter;
-        [self addSubview:_dateLabel];
-    }
-
-    return _dateLabel;
-}
-
-- (UIView *)selectionView
-{
-    if (!_selectionView) {
-        _selectionView = [[UIView alloc] initWithFrame:CGRectMake((self.frame.size.width - 51) / 2, self.frame.size.height - 3, 51, 3)];
-        _selectionView.alpha = 0;
-        _selectionView.backgroundColor = [UIColor colorWithRed:242./255. green:93./255. blue:28./255. alpha:1.];
-        [self addSubview:_selectionView];
-    }
-
-    return _selectionView;
 }
 
 - (void)setItemSelectionColor:(UIColor *)itemSelectionColor
@@ -118,6 +85,8 @@ const CGFloat kDIDatepickerSelectionLineWidth = 51.;
 - (void)setHighlighted:(BOOL)highlighted
 {
     [super setHighlighted:highlighted];
+    
+    self.selectionView.hidden = NO;
     if (highlighted) {
         self.selectionView.alpha = self.isSelected ? 1 : .5;
     } else {
@@ -125,26 +94,59 @@ const CGFloat kDIDatepickerSelectionLineWidth = 51.;
     }
 }
 
+- (void)setSelected:(BOOL)selected
+{
+    [super setSelected:selected];
+    self.selectionView.alpha = (selected)?1.0f:0.0f;
+}
 
-#pragma mark Other methods
+#pragma mark - Getters
+
+- (UILabel *)dateLabel
+{
+    if (!_dateLabel) {
+        _dateLabel = [[UILabel alloc] initWithFrame:self.bounds];
+        _dateLabel.numberOfLines = 2;
+        _dateLabel.textAlignment = NSTextAlignmentCenter;
+        [self addSubview:_dateLabel];
+    }
+    
+    return _dateLabel;
+}
+
+- (UIView *)selectionView
+{
+    if (!_selectionView) {
+        _selectionView = [[UIView alloc] initWithFrame:CGRectMake((CGRectGetWidth(self.frame) - 51) / 2, CGRectGetHeight(self.frame) - 3, 51, 3)];
+        _selectionView.alpha = 0.0f;
+        _selectionView.backgroundColor = [UIColor colorWithRed:242./255. green:93./255. blue:28./255. alpha:1.];
+        [self addSubview:_selectionView];
+    }
+    
+    return _selectionView;
+}
+
+- (NSDateFormatter *)dateFormatter
+{
+    if(!_dateFormatter){
+        _dateFormatter = [[NSDateFormatter alloc] init];
+    }
+    
+    return _dateFormatter;
+}
+
+#pragma mark - Helper Methods
 
 - (BOOL)isWeekday:(NSDate *)date
 {
     NSInteger day = [[[NSCalendar currentCalendar] components:NSWeekdayCalendarUnit fromDate:date] weekday];
-
+    
     const NSInteger kSunday = 1;
     const NSInteger kSaturday = 7;
-
+    
     BOOL isWeekdayResult = day == kSunday || day == kSaturday;
-
+    
     return isWeekdayResult;
-}
-
-- (void)dateWasSelected
-{
-    self.isSelected = YES;
-
-    [self sendActionsForControlEvents:UIControlEventValueChanged];
 }
 
 @end


### PR DESCRIPTION
I have updated the code to use a `UICollectionView` instead of a `UIScrollView`. In doing so, we can now use the power of reusable cells and therefore could load more dates than your maximum 1000 if needed, I has also simplified the scrolling logic as its already built in.

I have also fixed an issue with current `fillWeek` method. If in England or you have set `firstWeekday` to one on the gregorian calendar and the current day is `Sunday` the present code would display the wrong week. 

In addition to the above I have improved `selectDate:(NSDate *)date` previously it would almost always hit your assert because the NSDate didn't exist in your dates array due to having a different time. Using: `[[NSCalendar currentCalendar] rangeOfUnit:NSDayCalendarUnit startDate:&date interval:NULL forDate:date];` I have normalised the date (set time to 00:00) before we do the comparison.

I have removed the lazy helper function `fillDatesFromCurrentDate:` because its easy to call `fillDatesFromDate:[NSDate date] numberOfDays:` but feel free to add it back.

FYI, great project + design skills.