### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pod install
 Copy the folder `Sources/` to your project.
 
 
-##License
+## License
 
 Copyright (c) 2014 Dmitry Ivanenko 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
